### PR TITLE
Modernize build, add Islands theme support, fix disabled-text and project-view contrast

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -156,6 +156,9 @@ Temporary Items
 .gradle
 build/
 
+# IntelliJ Platform Gradle Plugin cache
+.intellijPlatform
+
 # Ignore Gradle GUI config
 gradle-app.setting
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,27 +1,37 @@
 plugins {
-    id "java"
-    id "org.jetbrains.intellij" version "1.0"
+    id "org.jetbrains.intellij.platform" version "2.17.0"
 }
 
 group "com.blai30"
-version "1.12"
+version "2.0.0"
 
 repositories {
     mavenCentral()
+    intellijPlatform {
+        defaultRepositories()
+    }
 }
 
 dependencies {
-    testImplementation "org.junit.jupiter:junit-jupiter-api:5.7.0"
-    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.7.0"
+    intellijPlatform {
+        intellijIdea("2025.3")
+    }
 }
 
-// See https://github.com/JetBrains/gradle-intellij-plugin/
-intellij {
-    version = "2021.1"
-    updateSinceUntilBuild = false
-}
-patchPluginXml {
-    changeNotes = """
+// See https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin.html
+intellijPlatform {
+    pluginConfiguration {
+        ideaVersion {
+            sinceBuild = "232"
+            untilBuild = provider { null }
+        }
+        changeNotes = """
+    <h4>2.0</h4>
+    <ul>
+        <li>Add support for the Islands theme.</li>
+        <li>Fix disabled control text being unreadable in both themes.</li>
+        <li>Fix the selected file being hard to see in the project view when the window is unfocused.</li>
+    </ul>
     <h4>1.12</h4>
     <h5>Lotus Light</h5>
     <ul>
@@ -83,12 +93,10 @@ patchPluginXml {
     <ul>
         <li>Update button colors.</li>
     </ul>
-
     <h4>1.1</h4>
     <ul>
         <li>Add plugin logo.</li>
     </ul>
-
     <h4>1.0</h4>
     <h5>Lotus Dark</h5>
     <ul>
@@ -98,9 +106,6 @@ patchPluginXml {
     <ul>
         <li>Initial release.</li>
     </ul>
-    ]]>
-      """
-}
-test {
-    useJUnitPlatform()
+        """
+    }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -25,10 +25,6 @@
     <h3>This theme includes colors for Rainbow Brackets.</h3>
     ]]></description>
 
-    <!-- please see https://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html for description -->
-    <!-- Theme plugins are only supported since version 2019.1 -->
-    <idea-version since-build="191.0"/>
-
     <!-- please see https://plugins.jetbrains.com/docs/intellij/plugin-compatibility.html
          on how to target different products -->
     <depends>com.intellij.modules.platform</depends>

--- a/src/main/resources/themes/Lotus_Dark.theme.json
+++ b/src/main/resources/themes/Lotus_Dark.theme.json
@@ -3,6 +3,7 @@
   "dark": true,
   "author": "blai30",
   "editorScheme": "/colors/Lotus_Dark.xml",
+  "parentTheme": "Islands Dark",
 
   "colors": {
     "backgroundColor": "#141414",
@@ -23,7 +24,8 @@
     "accentColor": "#670000",
     "excludedColor": "#3e1818",
     "selectionTransparentBackgroundColor": "#191919",
-    "treeInactiveSelectionColor": "#606060"
+    "treeInactiveSelectionColor": "#606060",
+    "mainWindowColor": "#262626"
   },
 
   "ui": {
@@ -182,7 +184,10 @@
       "background": "backgroundColor",
       "borderColor": "selectionBackgroundColor",
       "inactiveColoredFileBackground": "backgroundColor",
-      "underlinedTabBackground": "tableSelectedColor"
+      "underlinedTabBackground": "tableSelectedColor",
+      "underlinedBorderColor": "accentColor",
+      "inactiveUnderlinedTabBorderColor": "secondBorderColor",
+      "inactiveUnderlinedTabBackground": "backgroundColor"
     },
 
     "FileColor": {
@@ -221,6 +226,10 @@
       "borderColor": "backgroundColor"
     },
 
+    "Island": {
+      "borderColor": "backgroundColor"
+    },
+
     "Label": {
       "foreground": "foregroundColor",
       "infoForeground": "textColor",
@@ -240,6 +249,14 @@
       "selectionBackground": "selectionBackgroundColor",
       "selectionInactiveForeground": "selectionForegroundColor",
       "selectionInactiveBackground": "selectionTransparentBackgroundColor"
+    },
+
+    "MainToolbar": {
+      "borderColor": "#00000000"
+    },
+
+    "MainWindow": {
+      "background": "mainWindowColor"
     },
 
     "MemoryIndicator": {
@@ -485,7 +502,7 @@
     },
 
     "StatusBar": {
-      "borderColor": "backgroundColor"
+      "borderColor": "#00000000"
     },
 
     "TabbedPane": {
@@ -627,6 +644,10 @@
         "underlinedTabBackground": "backgroundColor",
         "underlinedTabInactiveBackground": "contrastColor",
         "hoverBackground": "highlightColor"
+      },
+
+      "Stripe": {
+        "borderColor": "#00000000"
       }
     },
 

--- a/src/main/resources/themes/Lotus_Dark.theme.json
+++ b/src/main/resources/themes/Lotus_Dark.theme.json
@@ -749,19 +749,10 @@
   "icons": {
     "ColorPalette": {
       "Checkbox.Background.Default": "#141414",
-      "Checkbox.Background.Default.Dark": "#141414",
       "Checkbox.Background.Disabled": "#343434",
-      "Checkbox.Background.Disabled.Dark": "#343434",
 
       "Checkbox.Border.Disabled": "#343434",
-      "Checkbox.Border.Disabled.Dark": "#343434",
-      "Checkbox.Border.Default": "#343434",
-      "Checkbox.Border.Default.Dark": "#343434",
-
-      "Checkbox.Focus.Thin.Default": "#141414",
-      "Checkbox.Focus.Thin.Default.Dark": "#141414",
-      "Checkbox.Focus.Wide.Default": "#141414",
-      "Checkbox.Focus.Wide.Default.Dark": "#141414"
+      "Checkbox.Border.Default": "#343434"
     }
   }
 }

--- a/src/main/resources/themes/Lotus_Dark.theme.json
+++ b/src/main/resources/themes/Lotus_Dark.theme.json
@@ -13,6 +13,7 @@
     "buttonColor": "#1C1C1C",
     "secondaryBackgroundColor": "#141414",
     "disabledColor": "#5A5A5A",
+    "disabledForegroundColor": "#828282",
     "contrastColor": "#101010",
     "tableSelectedColor": "#262626",
     "secondBorderColor": "#1E1E1E",
@@ -86,7 +87,7 @@
     "CheckBox": {
       "foreground": "foregroundColor",
       "background": "backgroundColor",
-      "disabledText": "disabledColor",
+      "disabledText": "disabledForegroundColor",
       "select": "selectionForegroundColor"
     },
 
@@ -95,7 +96,7 @@
       "background": "backgroundColor",
       "selectionForeground": "selectionForegroundColor",
       "selectionBackground": "selectionBackgroundColor",
-      "disabledForeground": "disabledColor",
+      "disabledForeground": "disabledForegroundColor",
       "disabledBackground": "backgroundColor",
       "acceleratorForeground": "textColor",
       "acceleratorSelectionForeground": "textColor"
@@ -109,14 +110,14 @@
     "ComboBox": {
       "foreground": "foregroundColor",
       "background": "backgroundColor",
-      "disabledForeground": "disabledColor",
+      "disabledForeground": "disabledForegroundColor",
       "selectionForeground": "foregroundColor",
       "selectionBackground": "tableSelectedColor",
       "nonEditableBackground": "backgroundColor",
       "ArrowButton": {
         "background": "buttonColor",
         "iconColor": "foregroundColor",
-        "disabledIconColor": "disabledColor",
+        "disabledIconColor": "disabledForegroundColor",
         "nonEditableBackground": "backgroundColor"
       }
     },
@@ -194,7 +195,7 @@
       "background": "backgroundColor",
       "selectionForeground": "selectionForegroundColor",
       "selectionBackground": "tableSelectedColor",
-      "inactiveForeground": "disabledColor"
+      "inactiveForeground": "disabledForegroundColor"
     },
 
     "Group": {
@@ -223,8 +224,8 @@
       "foreground": "foregroundColor",
       "infoForeground": "textColor",
       "selectedForeground": "selectionForegroundColor",
-      "disabledForeground": "disabledColor",
-      "disabledText": "disabledColor"
+      "disabledForeground": "disabledForegroundColor",
+      "disabledText": "disabledForegroundColor"
     },
 
     "Link": {
@@ -249,7 +250,7 @@
       "foreground": "foregroundColor",
       "selectionForeground": "selectionForegroundColor",
       "selectionBackground": "selectionBackgroundColor",
-      "disabledForeground": "disabledColor",
+      "disabledForeground": "disabledForegroundColor",
       "acceleratorForeground": "textColor",
       "acceleratorSelectionForeground": "selectionForegroundColor",
       "borderColor": "selectionBackgroundColor",
@@ -258,7 +259,7 @@
 
     "MenuBar": {
       "foreground": "foregroundColor",
-      "disabledForeground": "disabledColor",
+      "disabledForeground": "disabledForegroundColor",
       "disabledBackground": "backgroundColor",
       "borderColor": "backgroundColor",
       "highlight": "backgroundColor",
@@ -267,7 +268,7 @@
 
     "MenuItem": {
       "foreground": "foregroundColor",
-      "disabledForeground": "disabledColor",
+      "disabledForeground": "disabledForegroundColor",
       "selectionForeground": "selectionForegroundColor",
       "selectionBackground": "selectionBackgroundColor",
       "acceleratorForeground": "textColor"
@@ -309,7 +310,7 @@
       "foreground": "foregroundColor",
       "background": "backgroundColor",
       "borderColor": "tableSelectedColor",
-      "disabledForeground": "disabledColor",
+      "disabledForeground": "disabledForegroundColor",
       "infoForeground": "textColor",
       "currentOverloadBackground": "highlightColor",
       "lineSeparatorColor": "tableSelectedColor"
@@ -320,11 +321,11 @@
       "background": "backgroundColor",
       "selectionForeground": "selectionForegroundColor",
       "selectionBackground": "tableSelectedColor",
-      "inactiveForeground": "disabledColor"
+      "inactiveForeground": "disabledForegroundColor"
     },
 
     "Plugins": {
-      "disabledForeground": "disabledColor",
+      "disabledForeground": "disabledForegroundColor",
       "lightSelectionBackground": "selectionBackgroundColor",
       "tagBackground": "highlightColor",
       "eapTagBackground": "highlightColor",
@@ -339,7 +340,7 @@
         "installForeground": "foregroundColor",
         "installBackground": "buttonColor",
         "installBorderColor":"buttonColor",
-        "installFillForeground": "disabledColor",
+        "installFillForeground": "disabledForegroundColor",
         "installFillBackground": "buttonColor",
         "installFocusedBackground": "highlightColor",
         "updateForeground":"foregroundColor",
@@ -395,13 +396,13 @@
     "RadioButton": {
       "foreground": "foregroundColor",
       "background": "backgroundColor",
-      "disabledText": "disabledColor"
+      "disabledText": "disabledForegroundColor"
     },
 
     "RadioButtonMenuItem": {
       "foreground": "foregroundColor",
       "selectionBackground": "selectionBackgroundColor",
-      "disabledForeground": "disabledColor",
+      "disabledForeground": "disabledForegroundColor",
       "acceleratorForeground": "textColor",
       "acceleratorSelectionForeground": "textColor"
     },
@@ -431,7 +432,7 @@
       "SearchField": {
         "background": "contrastColor",
         "borderColor": "backgroundColor",
-        "infoForeground": "disabledColor"
+        "infoForeground": "disabledForegroundColor"
       },
 
       "Tab": {
@@ -489,8 +490,8 @@
     "TabbedPane": {
       "foreground": "foregroundColor",
       "background": "backgroundColor",
-      "disabledForeground": "disabledColor",
-      "disabledUnderlineColor": "disabledColor",
+      "disabledForeground": "disabledForegroundColor",
+      "disabledUnderlineColor": "disabledForegroundColor",
       "hoverColor": "highlightColor",
       "focusColor": "tableSelectedColor",
       "contentAreaColor": "highlightColor"
@@ -526,7 +527,7 @@
     "TextArea": {
       "foreground": "foregroundColor",
       "background": "backgroundColor",
-      "inactiveForeground": "disabledColor",
+      "inactiveForeground": "disabledForegroundColor",
       "selectionForeground": "selectionForegroundColor",
       "selectionBackground": "tableSelectedColor"
     },
@@ -537,7 +538,7 @@
     "TextField": {
       "foreground": "foregroundColor",
       "background": "backgroundColor",
-      "inactiveForeground": "disabledColor",
+      "inactiveForeground": "disabledForegroundColor",
       "selectionForeground": "selectionForegroundColor",
       "selectionBackground": "tableSelectedColor"
     },
@@ -545,7 +546,7 @@
     "TextPane": {
       "foreground": "foregroundColor",
       "background": "backgroundColor",
-      "inactiveForeground": "disabledColor",
+      "inactiveForeground": "disabledForegroundColor",
       "selectionForeground": "selectionForegroundColor",
       "selectionBackground": "tableSelectedColor"
     },
@@ -571,7 +572,7 @@
       "offBackground": "foregroundColor",
       "buttonColor":  "buttonColor",
       "borderColor": "buttonColor",
-      "disabledText": "disabledColor"
+      "disabledText": "disabledForegroundColor"
     },
 
     "Toolbar": {
@@ -668,7 +669,7 @@
       },
 
       "HgLog": {
-        "closedBranchIconColor": "disabledColor",
+        "closedBranchIconColor": "disabledForegroundColor",
         "localTagIconColor": "textColor",
         "mqTagIconColor": "textColor",
         "tagIconColor": "textColor",

--- a/src/main/resources/themes/Lotus_Dark.theme.json
+++ b/src/main/resources/themes/Lotus_Dark.theme.json
@@ -22,7 +22,8 @@
     "notificationsColor": "#111111",
     "accentColor": "#670000",
     "excludedColor": "#3e1818",
-    "selectionTransparentBackgroundColor": "#191919"
+    "selectionTransparentBackgroundColor": "#191919",
+    "treeInactiveSelectionColor": "#606060"
   },
 
   "ui": {
@@ -634,7 +635,8 @@
       "background": "contrastColor",
       "selectionForeground": "selectionForegroundColor",
       "selectionBackground": "treeSelectionColor",
-      "selectionInactiveBackground": "tableSelectedColor",
+      "selectionInactiveBackground": "treeInactiveSelectionColor",
+      "selectionInactiveForeground": "selectionForegroundColor",
       "hash": "secondBorderColor"
     },
 

--- a/src/main/resources/themes/Lotus_Light.theme.json
+++ b/src/main/resources/themes/Lotus_Light.theme.json
@@ -3,6 +3,7 @@
   "dark": false,
   "author": "blai30",
   "editorScheme": "/colors/Lotus_Light.xml",
+  "parentTheme": "Islands Light",
 
   "colors": {
     "backgroundColor": "#fafafa",
@@ -23,7 +24,8 @@
     "accentColor": "#de67bb",
     "excludedColor": "#eae8e8",
     "selectionTransparentBackgroundColor": "#aaaaaa",
-    "treeInactiveSelectionColor": "#898989"
+    "treeInactiveSelectionColor": "#898989",
+    "mainWindowColor": "#E2E2E2"
   },
 
   "ui": {
@@ -182,7 +184,10 @@
       "background": "backgroundColor",
       "borderColor": "secondaryBackgroundColor",
       "inactiveColoredFileBackground": "backgroundColor",
-      "underlinedTabBackground": "tableSelectedColor"
+      "underlinedTabBackground": "tableSelectedColor",
+      "underlinedBorderColor": "accentColor",
+      "inactiveUnderlinedTabBorderColor": "secondBorderColor",
+      "inactiveUnderlinedTabBackground": "backgroundColor"
     },
 
     "FileColor": {
@@ -221,6 +226,10 @@
       "borderColor": "backgroundColor"
     },
 
+    "Island": {
+      "borderColor": "backgroundColor"
+    },
+
     "Label": {
       "foreground": "foregroundColor",
       "infoForeground": "textColor",
@@ -240,6 +249,14 @@
       "selectionBackground": "selectionBackgroundColor",
       "selectionInactiveForeground": "selectionForegroundColor",
       "selectionInactiveBackground": "selectionTransparentBackgroundColor"
+    },
+
+    "MainToolbar": {
+      "borderColor": "#00000000"
+    },
+
+    "MainWindow": {
+      "background": "mainWindowColor"
     },
 
     "MemoryIndicator": {
@@ -485,7 +502,7 @@
     },
 
     "StatusBar": {
-      "borderColor": "backgroundColor"
+      "borderColor": "#00000000"
     },
 
     "TabbedPane": {
@@ -627,6 +644,10 @@
         "underlinedTabBackground": "backgroundColor",
         "underlinedTabInactiveBackground": "contrastColor",
         "hoverBackground": "highlightColor"
+      },
+
+      "Stripe": {
+        "borderColor": "#00000000"
       }
     },
 

--- a/src/main/resources/themes/Lotus_Light.theme.json
+++ b/src/main/resources/themes/Lotus_Light.theme.json
@@ -13,6 +13,7 @@
     "buttonColor": "#f3f4f5",
     "secondaryBackgroundColor": "#fafafa",
     "disabledColor": "#d2d4d5",
+    "disabledForegroundColor": "#6F6F6F",
     "contrastColor": "#f4f4f4",
     "tableSelectedColor": "#e7e7e8",
     "secondBorderColor": "#d3e1e8",
@@ -86,7 +87,7 @@
     "CheckBox": {
       "foreground": "foregroundColor",
       "background": "backgroundColor",
-      "disabledText": "disabledColor",
+      "disabledText": "disabledForegroundColor",
       "select": "selectionForegroundColor"
     },
 
@@ -95,7 +96,7 @@
       "background": "backgroundColor",
       "selectionForeground": "selectionForegroundColor",
       "selectionBackground": "selectionBackgroundColor",
-      "disabledForeground": "disabledColor",
+      "disabledForeground": "disabledForegroundColor",
       "disabledBackground": "backgroundColor",
       "acceleratorForeground": "textColor",
       "acceleratorSelectionForeground": "textColor"
@@ -109,14 +110,14 @@
     "ComboBox": {
       "foreground": "foregroundColor",
       "background": "backgroundColor",
-      "disabledForeground": "disabledColor",
+      "disabledForeground": "disabledForegroundColor",
       "selectionForeground": "foregroundColor",
       "selectionBackground": "tableSelectedColor",
       "nonEditableBackground": "backgroundColor",
       "ArrowButton": {
         "background": "buttonColor",
         "iconColor": "foregroundColor",
-        "disabledIconColor": "disabledColor",
+        "disabledIconColor": "disabledForegroundColor",
         "nonEditableBackground": "backgroundColor"
       }
     },
@@ -194,7 +195,7 @@
       "background": "backgroundColor",
       "selectionForeground": "selectionForegroundColor",
       "selectionBackground": "tableSelectedColor",
-      "inactiveForeground": "disabledColor"
+      "inactiveForeground": "disabledForegroundColor"
     },
 
     "Group": {
@@ -223,8 +224,8 @@
       "foreground": "foregroundColor",
       "infoForeground": "textColor",
       "selectedForeground": "selectionForegroundColor",
-      "disabledForeground": "disabledColor",
-      "disabledText": "disabledColor"
+      "disabledForeground": "disabledForegroundColor",
+      "disabledText": "disabledForegroundColor"
     },
 
     "Link": {
@@ -249,7 +250,7 @@
       "foreground": "foregroundColor",
       "selectionForeground": "selectionForegroundColor",
       "selectionBackground": "selectionBackgroundColor",
-      "disabledForeground": "disabledColor",
+      "disabledForeground": "disabledForegroundColor",
       "acceleratorForeground": "textColor",
       "acceleratorSelectionForeground": "selectionForegroundColor",
       "borderColor": "secondaryBackgroundColor",
@@ -258,7 +259,7 @@
 
     "MenuBar": {
       "foreground": "foregroundColor",
-      "disabledForeground": "disabledColor",
+      "disabledForeground": "disabledForegroundColor",
       "disabledBackground": "backgroundColor",
       "borderColor": "backgroundColor",
       "highlight": "backgroundColor",
@@ -267,7 +268,7 @@
 
     "MenuItem": {
       "foreground": "foregroundColor",
-      "disabledForeground": "disabledColor",
+      "disabledForeground": "disabledForegroundColor",
       "selectionForeground": "selectionForegroundColor",
       "selectionBackground": "selectionBackgroundColor",
       "acceleratorForeground": "textColor"
@@ -309,7 +310,7 @@
       "foreground": "foregroundColor",
       "background": "secondaryBackgroundColor",
       "borderColor": "tableSelectedColor",
-      "disabledForeground": "disabledColor",
+      "disabledForeground": "disabledForegroundColor",
       "infoForeground": "textColor",
       "currentOverloadBackground": "highlightColor",
       "lineSeparatorColor": "tableSelectedColor"
@@ -320,11 +321,11 @@
       "background": "backgroundColor",
       "selectionForeground": "selectionForegroundColor",
       "selectionBackground": "tableSelectedColor",
-      "inactiveForeground": "disabledColor"
+      "inactiveForeground": "disabledForegroundColor"
     },
 
     "Plugins": {
-      "disabledForeground": "disabledColor",
+      "disabledForeground": "disabledForegroundColor",
       "lightSelectionBackground": "selectionBackgroundColor",
       "tagBackground": "highlightColor",
       "eapTagBackground": "highlightColor",
@@ -339,7 +340,7 @@
         "installForeground": "foregroundColor",
         "installBackground": "buttonColor",
         "installBorderColor":"buttonColor",
-        "installFillForeground": "disabledColor",
+        "installFillForeground": "disabledForegroundColor",
         "installFillBackground": "buttonColor",
         "installFocusedBackground": "highlightColor",
         "updateForeground":"foregroundColor",
@@ -395,13 +396,13 @@
     "RadioButton": {
       "foreground": "foregroundColor",
       "background": "backgroundColor",
-      "disabledText": "disabledColor"
+      "disabledText": "disabledForegroundColor"
     },
 
     "RadioButtonMenuItem": {
       "foreground": "foregroundColor",
       "selectionBackground": "selectionBackgroundColor",
-      "disabledForeground": "disabledColor",
+      "disabledForeground": "disabledForegroundColor",
       "acceleratorForeground": "textColor",
       "acceleratorSelectionForeground": "textColor"
     },
@@ -431,7 +432,7 @@
       "SearchField": {
         "background": "contrastColor",
         "borderColor": "backgroundColor",
-        "infoForeground": "disabledColor"
+        "infoForeground": "disabledForegroundColor"
       },
 
       "Tab": {
@@ -489,8 +490,8 @@
     "TabbedPane": {
       "foreground": "foregroundColor",
       "background": "backgroundColor",
-      "disabledForeground": "disabledColor",
-      "disabledUnderlineColor": "disabledColor",
+      "disabledForeground": "disabledForegroundColor",
+      "disabledUnderlineColor": "disabledForegroundColor",
       "hoverColor": "highlightColor",
       "focusColor": "tableSelectedColor",
       "contentAreaColor": "highlightColor"
@@ -526,7 +527,7 @@
     "TextArea": {
       "foreground": "foregroundColor",
       "background": "secondaryBackgroundColor",
-      "inactiveForeground": "disabledColor",
+      "inactiveForeground": "disabledForegroundColor",
       "selectionForeground": "selectionForegroundColor",
       "selectionBackground": "tableSelectedColor"
     },
@@ -537,7 +538,7 @@
     "TextField": {
       "foreground": "foregroundColor",
       "background": "backgroundColor",
-      "inactiveForeground": "disabledColor",
+      "inactiveForeground": "disabledForegroundColor",
       "selectionForeground": "selectionForegroundColor",
       "selectionBackground": "tableSelectedColor"
     },
@@ -545,7 +546,7 @@
     "TextPane": {
       "foreground": "foregroundColor",
       "background": "backgroundColor",
-      "inactiveForeground": "disabledColor",
+      "inactiveForeground": "disabledForegroundColor",
       "selectionForeground": "selectionForegroundColor",
       "selectionBackground": "tableSelectedColor"
     },
@@ -571,7 +572,7 @@
       "offBackground": "foregroundColor",
       "buttonColor":  "buttonColor",
       "borderColor": "buttonColor",
-      "disabledText": "disabledColor"
+      "disabledText": "disabledForegroundColor"
     },
 
     "Toolbar": {
@@ -668,7 +669,7 @@
       },
 
       "HgLog": {
-        "closedBranchIconColor": "disabledColor",
+        "closedBranchIconColor": "disabledForegroundColor",
         "localTagIconColor": "textColor",
         "mqTagIconColor": "textColor",
         "tagIconColor": "textColor",

--- a/src/main/resources/themes/Lotus_Light.theme.json
+++ b/src/main/resources/themes/Lotus_Light.theme.json
@@ -757,19 +757,10 @@
       "Objects.YellowDark": "#000000",
 
       "Checkbox.Background.Default": "#FAFAFA",
-      "Checkbox.Background.Default.Dark": "#141414",
       "Checkbox.Background.Disabled": "#727272",
-      "Checkbox.Background.Disabled.Dark": "#222222",
 
       "Checkbox.Border.Disabled": "#222222",
-      "Checkbox.Border.Disabled.Dark": "#222222",
-      "Checkbox.Border.Default": "#343434",
-      "Checkbox.Border.Default.Dark": "#343434",
-
-      "Checkbox.Focus.Thin.Default": "#141414",
-      "Checkbox.Focus.Thin.Default.Dark": "#141414",
-      "Checkbox.Focus.Wide.Default": "#141414",
-      "Checkbox.Focus.Wide.Default.Dark": "#141414"
+      "Checkbox.Border.Default": "#343434"
     }
   }
 }

--- a/src/main/resources/themes/Lotus_Light.theme.json
+++ b/src/main/resources/themes/Lotus_Light.theme.json
@@ -22,7 +22,8 @@
     "notificationsColor": "#eae8e8",
     "accentColor": "#de67bb",
     "excludedColor": "#eae8e8",
-    "selectionTransparentBackgroundColor": "#aaaaaa"
+    "selectionTransparentBackgroundColor": "#aaaaaa",
+    "treeInactiveSelectionColor": "#898989"
   },
 
   "ui": {
@@ -634,7 +635,8 @@
       "background": "contrastColor",
       "selectionForeground": "selectionForegroundColor",
       "selectionBackground": "treeSelectionColor",
-      "selectionInactiveBackground": "tableSelectedColor",
+      "selectionInactiveBackground": "treeInactiveSelectionColor",
+      "selectionInactiveForeground": "selectionForegroundColor",
       "hash": "secondBorderColor"
     },
 


### PR DESCRIPTION
## Summary
- Migrated the Gradle build off the deprecated `org.jetbrains.intellij` 1.x plugin onto `org.jetbrains.intellij.platform` 2.x (2.17.0), bumped the Gradle wrapper 7.2 -> 9.6.1, moved since/until-build management into Gradle (`sinceBuild = "232"`, no ceiling), and dropped vestigial JUnit scaffolding (the project has zero test files).
- Fixed #7: disabled combo boxes (and every other disabled control) were unreadable in both themes because the shared `disabledColor` token doubled as both a foreground/text color and a background fill. Added a dedicated `disabledForegroundColor` token per theme (~4.5:1+ contrast) and repointed only the foreground/text/icon-role usages to it.
- Fixed #8: the currently-selected file was nearly invisible in the Project view when the tool window lost focus (e.g. with "Always Select Opened File"), because the inactive-selection highlight reused a token nearly identical to the tree's own background. Added a dedicated `treeInactiveSelectionColor` token (>=3:1 contrast) and an explicit inactive-selection foreground.
- Added compatibility with JetBrains' new Islands UI theme (default since IDE 2025.3): `parentTheme` declarations, transparent sidebar borders, a `MainWindow.background` token meeting JetBrains' recommended 1.20:1 contrast ratio, and the new `EditorTabs`/`Island`/`ToolWindow.Stripe` keys per JetBrains' official adaptation guide.
- Removed deprecated/unsupported checkbox icon-palette keys, found via a live sandbox IDE run that logged real deprecation warnings for both themes.
- Version bump 1.12 -> 2.0.0 with a changelog entry.

## Test plan
- [x] `./gradlew build` succeeds (verified repeatedly, including a from-scratch `clean build`)
- [x] All color-contrast fixes verified against WCAG contrast-ratio math via a throwaway script (not shipped) - disabled text 4.79:1/4.81:1, tree inactive selection 3.03:1/3.18:1, Islands MainWindow 1.22:1/1.24:1
- [x] `./gradlew runIde` launched a real IntelliJ IDEA 2025.3 sandbox; both themes loaded with no fatal errors
- [x] Every task individually reviewed (spec compliance + code quality) and a final whole-branch review, both clean - no Critical/Important findings